### PR TITLE
Double proxy setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,52 @@ Based on the excellent [heroku-buildpack-stack][4].
 
 Push an app with version 1.0 of this buildpack:
 
-    $ cf push haskell-api -b  https://github.com/mikegehard/cloudfoundry-buildpack-haskell-stack#1.0 -m 2GB
+```
+$ cf push haskell-api -b  https://github.com/mikegehard/cloudfoundry-buildpack-haskell-stack#1.0 -m 2GB
+```
+
+### Proxy
+
+#### One Proxy
+
+If you're behind a proxy, simply set ```https_proxy``` environment variable to the desired value (e.g. in the manifest) and the buildpack will pick it up.
+
+#### Two Proxies
+
+If your PCF instance is behind a proxy and you find yourself in a situation where:
+
+* it takes one proxy setting to let your buildpack download Stack from the Internet (```proxy.example.com:80```)
+* but it also takes another proxy setting to let Stack download its dependencies (```http://user:password@proxy.anotherexample.com```)
+* and those two proxy settings are different
+
+this buildpack lets you configure your second proxy by setting the
+
+```
+stack_proxy
+```
+
+environment variable (e.g. in the manifest) to the desired value. The way the buildpack is going to work is:
+
+* it will use the ```https_proxy``` as it would in the one proxy scenario
+* as it detects the moment where Stack starts pulling its dependencies, it will temporarily swap the current proxy setting with with the ```stack_proxy``` setting.
+
+### Sample Manifest
+
+```yml
+---
+applications:
+- name: your-application-name
+  buildpacks:
+  - https://github.com/mikegehard/cloudfoundry-buildpack-haskell-stack
+  instances: 1
+  memory: 2G
+  disk_quota: 2G
+  health-check-type: process
+  timeout: 180
+  env:
+    https_proxy: "proxy.example.com:80"
+    stack_proxy: "http://user:password@proxy.anotherexample.com"
+```
 
 **Note: The first push of an application requires a lot of memory to prime the Stack cache with all of the libraries. It is recommended that you set the app memory to 2GB for the first push and scale it back down after the push completes. You may also need to scale up before subsequent pushes and scale down after those pushes complete. It seems that the v3 Cloud Controller API will allow for setting the compilation container memory differently than the runtime container memory so this may go away in the future.**
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,60 +1,112 @@
 #!/usr/bin/env bash
 # bin/compile <build-dir> <cache-dir>
 
-# Thanks to https://github.com/mfine/heroku-buildpack-stack/blob/master/bin/compile
-# for the inspiration.
-
-set -e
-set -o pipefail
-
-BUILD_DIR="$1"
-CACHE_DIR="$2"
+##### helper functions -> #############
 
 function speak (){
   echo "-----> $(date -u '+%Y-%m-%d_%H:%M:%S') $1"
 }
 
-speak "Starting..."
+##### <- helper functions #############
 
-export LANG=en_US.UTF-8
-# Make sure all the stack stuff ends up in the cache as well
-# This will allow for faster compiles on subsequent pushes.
-export STACK_ROOT=$CACHE_DIR/.stack
+speak "Compiling with Haskell Cloud Foundry Buildpack."
 
-########## stack exe ###############################################
-STACK_VER=${STACK_VER:-1.2.0}
-STACK_URL=${STACK_URL:-https://github.com/commercialhaskell/stack/releases/download/v"$STACK_VER"/stack-"$STACK_VER"-linux-x86_64.tar.gz}
-STACK_DIR="$CACHE_DIR/stack-$STACK_VER"
+##### preparation -> ##################
+
+set -e
+set -o pipefail
+
+BUILD_DIR="$1"
+speak "Build directory: $BUILD_DIR."
+
+CACHE_DIR="$2"
+speak "Cache directory: $CACHE_DIR."
+
+if [ -d $CACHE_DIR/.stack ]
+then
+	speak "Stack cache directory found: $CACHE_DIR/.stack."
+	ls $CACHE_DIR/.stack
+else
+	speak "Stack cache directory not found: $CACHE_DIR/.stack."
+fi
+
+PRESERVED_HTTPS_PROXY=$https_proxy
+STACK_PROXY=$stack_proxy
+if [ -z "$STACK_PROXY" ]
+then
+	speak "Stack proxy not found. If you have a proxy configured (https_proxy environment variable), it will not be ovewritten during this compilation."
+else
+	speak "Stack proxy found: $STACK_PROXY. If you have a proxy configured (https_proxy environment variable), it will be ovewritten for the duration of this compilation."
+fi
+
+##### <- preparation ##################
+
+##### getting stack -> ################
+
+STACK_VER="1.9.3"
+STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v"$STACK_VER"/stack-"$STACK_VER"-linux-x86_64.tar.gz"
+STACK_NAME="stack-$STACK_VER"
+STACK_DIR="$CACHE_DIR/$STACK_NAME"
 STACK_EXE="$STACK_DIR/stack"
-if [ ! -e "$STACK_EXE" ]; then
-  speak "Downloading stack-$STACK_VER"
-  mkdir -p "$STACK_DIR"
-  curl -# -L "$STACK_URL" | tar xz -C "$STACK_DIR" --strip-components=1
-  chmod u+x $STACK_EXE
+if [ ! -e "$STACK_EXE" ]
+then
+	speak "Downloading Stack version $STACK_NAME."
+	mkdir -p "$STACK_DIR"
+	curl -# -L "$STACK_URL" | tar xz -C "$STACK_DIR" --strip-components=1
+	chmod u+x $STACK_EXE
+else
+	speak "Stack version $STACK_NAME already downloaded."
 fi
 
-########## project build ###########################################
-STACK_DIR=".stack-work"
-SANDBOX_DIR="$CACHE_DIR/$STACK_DIR"
-if [ -e "$SANDBOX_DIR" ]; then
-    speak "Restoring $STACK_DIR to $BUILD_DIR"
-    cp -Rp "$SANDBOX_DIR" "$BUILD_DIR"
+##### <- getting stack ################
+
+##### building the project -> #########
+
+STACK_WORK_DIR=".stack-work"
+SANDBOX_DIR="$CACHE_DIR/$STACK_WORK_DIR"
+if [ -e "$SANDBOX_DIR" ]
+then
+	speak "Restoring $SANDBOX_DIR to $BUILD_DIR."
+	cp -Rp "$SANDBOX_DIR" "$BUILD_DIR"
+else
+	speak "Stack work directory $SANDBOX_DIR not found."
 fi
 
-speak "Running stack"
+if [ ! -z "$STACK_PROXY" ]
+then
+	speak "Updating your current proxy setting: $https_proxy."
+	export https_proxy=$STACK_PROXY
+	speak "Your new temporary proxy setting: $https_proxy."
+fi
+
+speak "Running Stack."
 cd "$BUILD_DIR"
 $STACK_EXE setup
 $STACK_EXE build --fast
 
-speak "Making stack binaries available"
+speak "Making Stack binaries available."
 mkdir -p "$BUILD_DIR/bin"
 mv $($STACK_EXE path --local-install-root)/bin/* $BUILD_DIR/bin
 
-speak "Writing out start script"
+speak "Writing out the start script."
 echo -e "---\ndefault_process_types:\n  web: /home/vcap/app/bin/`ls $BUILD_DIR/bin`" > $BUILD_DIR/startScript.yml
 
-speak "Caching .stack-work"
+speak "Caching .stack-work."
 rm -rf $SANDBOX_DIR
-cp -Rp $BUILD_DIR/$STACK_DIR $SANDBOX_DIR
+cp -Rp $BUILD_DIR/$STACK_WORK_DIR $SANDBOX_DIR
+
+##### <- building the project #########
+
+##### cleanup -> ######################
+
+if [ ! -z "$STACK_PROXY" ]
+then
+	speak "Cleaning up."
+	speak "Current value of your proxy setting is: $https_proxy. Restoring to your previous proxy setting: $PRESERVED_HTTPS_PROXY."
+	export https_proxy=$PRESERVED_HTTPS_PROXY
+	speak "Your proxy is back to: $https_proxy."
+fi
+
+##### <- cleanup ######################
 
 speak "Finished!"


### PR DESCRIPTION
Made the buildpack work in double proxy scenarios (fixes https://github.com/mikegehard/cloudfoundry-buildpack-haskell-stack/issues/1), updated the readme file. Also updated Stack version to 1.9.3.